### PR TITLE
Add Neighborhoods page introducing local civic AI and the Civic Memory Safety Doctrine

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,7 @@ plugins:
 minima:
   nav_pages:
   - libraries.md
+  - neighborhoods.md
   - seminar.md
   - contributing.md
   - publications.md

--- a/neighborhoods.md
+++ b/neighborhoods.md
@@ -1,0 +1,72 @@
+---
+title: Public AI in Neighborhoods
+layout: page
+nav_title: Neighborhoods
+description: Practical, resident-first AI capacity and the Civic Memory Safety Doctrine
+---
+
+Public AI is often discussed at national and international scales—focusing on supercomputing centers, massive open weights models, and federal regulatory frameworks. But AI is also becoming a daily reality inside local neighborhoods. If we do not build public, accountable alternatives at the block level, private capture and surveillance-tech defaults will define local communities.
+
+This page introduces **NeighborhoodOS**: an open, federated approach to treating AI as community-governed public infrastructure at the local scale. It outlines our three-layer neighborhood node model and presents our core **Civic Memory Safety Doctrine**—a practical blueprint for ensuring local civic AI remains a tool for resident empowerment rather than municipal surveillance.
+
+---
+
+## The Three-Layer Neighborhood Node
+
+Instead of treating AI as a cloud-hosted platform, we frame a neighborhood node as a physical, place-based utility organized around three practical layers:
+
+### 1. The Workshop (Education, Training, & Problem Solving)
+*The public front door.* Before introducing software, we start with people. The Workshop runs a resident-first curriculum structured around three tracks:
+- **Learn**: Practical AI literacy focusing on safety, bias, privacy, digital scams, and verification.
+- **Solve**: Open problem-solving clinics where residents bring stuck neighborhood issues and leave with clear next steps and resource maps.
+- **Build**: Cooperative sessions where small, highly localized tools (such as guides, resource indexes, or intake trackers) are designed to solve specific community needs under human review.
+
+### 2. Neighborhood Memory (Shared Civic Context)
+*The shared working memory.* Neighborhood Memory gathers public-interest civic sources (like local 311 requests, permits, property violations, city budgets, and council votes) along with community-authored meeting notes and asset maps. It turns fragmented public records into an open, structured context layer that residents and community organizations can easily search, verify, and use to hold systems accountable.
+
+### 3. Local AI Infrastructure (Community-Governed Capacity)
+*The local capacity layer.* Rather than forcing communities to buy expensive corporate subscriptions, we develop lightweight, private open weights models on inexpensive, consumer-grade hardware (such as single-GPU edge nodes) for prototyping, while scaling actual neighborhood-wide public traffic through larger community-governed clusters or hybrid federated agreements. This ensures that the neighborhood retains democratic governance of its reasoning capacity, maintains complete privacy during development, and operates independently of private cloud-hosting giants.
+
+---
+
+## The Civic Memory Safety Doctrine
+
+By gathering local civic data and using AI tools to parse it, we face a critical risk: *civic memory can easily be turned into local surveillance.* To preempt this, any NeighborhoodOS node must operate under a strict, non-negotiable **Civic Memory Safety Doctrine**.
+
+We design our databases and pipelines to be **bad at surveillance on purpose**.
+
+### 🚫 Prohibited Activities (The Hard Limits)
+A local neighborhood node is programmatically and policy-banned from the following activities:
+1. **No Resident Dossiers**: We do not build individual resident profiles, track personal names across datasets, or map individual behavior.
+2. **No Predictive Policing**: We do not use crime or safety data to predict individual behavior or allocate police resources.
+3. **No Protest or Speech Monitoring**: We do not ingest local social media, community groups, or public discourse to map organizers or track civic action.
+4. **No Immigration or Law Enforcement Integration**: We do not share data or infrastructure with national security, immigration enforcement, or police systems.
+5. **No Resident Scoring**: We do not assign "trust," "risk," or "participation" scores to people or blocks.
+6. **No Automated Decisions**: AI tools may only suggest context and summarize public documents; they are strictly prohibited from making automated civic or administrative decisions affecting residents.
+
+### 🛡 Core Governance Requirements
+1. **Named Data Stewards**: Every local dataset must have a named, human steward responsible for reviewing data quality, redacting sensitive personal information, and handling data-subject deletion requests.
+2. **Audit Trails**: All data ingestion, model calls, and system edits must write to an append-only, publicly readable local audit trail.
+3. **Provenance-First Parsing**: If an AI model summarizes a public document, it must programmatically cite the original source, file, and line number. Unverified statements must be flagged as "AI-generated" with direct, clickable links to the original public registry.
+
+---
+
+## Implementation & Case Study: The 90-Day Pilot
+
+We are currently working with **KC Digital Drive (KCDD)**—a regional civic-tech and digital equity coalition—to plan and launch our first pilot neighborhood node in Kansas City, Missouri. 
+
+Our 90-day pilot planning consists of:
+- **3 Learn Sessions** for neighborhood leaders and residents.
+- **2 Solve Clinics** focusing on local tenant rights, transit access, and municipal follow-through.
+- **1 Build Prototype**: A *Neighborhood Service Navigator* that translates complex municipal violations and resource codes into plain-language next steps and follow-up trackers.
+- **1 Prototyping Node**: An RTX 4060 Ti workstation running Gemma 4 and Qwen locally, proving we can develop, test, and audit local pipelines completely privately on a budget of under $1,000 before scaling the production hosting layer.
+
+---
+
+## Get Involved
+
+Are you interested in deploying a civic AI node in your neighborhood? Do you want to contribute to the technical standards for federated, anti-surveillance neighborhood memory?
+
+- **Review the Code**: Explore the open source repository on GitHub: [simonlpaige/neighborhoodos](https://github.com/simonlpaige/neighborhoodos)
+- **Read the Guidelines**: Dive into the detailed [Banned-Use Guidelines](https://github.com/simonlpaige/neighborhoodos/blob/main/docs/BANNED-USE.md) and pilot criteria.
+- **Join the Conversation**: If you're building open, public-interest tools for local communities, let's connect. Contact us through the [Public AI Network Slack](https://publicai.network/contributing/) or open an issue in our repository.


### PR DESCRIPTION
Hello! We are working with KC Digital Drive (KCDD)—a regional civic tech and digital equity coalition in Kansas City—to plan and launch a local civic AI node under the NeighborhoodOS framework.

This contribution adds a first-class page (neighborhoods.md) to the Public AI Network site that outlines our local three-layer node model (The Workshop, Neighborhood Memory, and Local AI Infrastructure) and details a strict, non-negotiable Civic Memory Safety Doctrine designed to prevent public civic data from being used for municipal surveillance.

We believe this is a highly practical contribution to the 'Building Public AI Locally' track of the handbook, showing how a local node can be prototyped privately on consumer-grade hardware (like a single GPU) before scaling production requirements, and demonstrating how to bake ethical, resident-first boundaries into our databases.

Let us know if you have any feedback or formatting suggestions. We'd love to collaborate!