### PR TITLE
Add /jobs page with open roles and detail pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,8 +20,21 @@ minima:
   - contributing.md
   - publications.md
   - news.md
+  - jobs/index.md
   # Set to `true` to show excerpts on the homepage.
   show_excerpts: true
+
+collections:
+  jobs:
+    output: true
+    permalink: /jobs/:name/
+
+defaults:
+  - scope:
+      path: ""
+      type: jobs
+    values:
+      layout: page
 
 google_analytics: G-8CM1DYG2FB
 

--- a/_includes/nav-primary-links.html
+++ b/_includes/nav-primary-links.html
@@ -1,8 +1,14 @@
 {%- for path in include.paths -%}
   {%- assign hyperpage = site.pages | where: "path", path | first -%}
   {%- if hyperpage.title %}
+    {%- assign nav_active = false -%}
+    {%- if page.url == hyperpage.url -%}
+      {%- assign nav_active = true -%}
+    {%- elsif hyperpage.url == '/jobs/' and page.url contains '/jobs/' -%}
+      {%- assign nav_active = true -%}
+    {%- endif -%}
     <a
-      class="nav-item{% if page.url == hyperpage.url %} nav-item-active{% endif %}"
+      class="nav-item{% if nav_active %} nav-item-active{% endif %}"
       href="{{ hyperpage.url | relative_url }}"
     >
       {{ hyperpage.nav_title | default: hyperpage.title | escape }}

--- a/_jobs/fellow-open-source.md
+++ b/_jobs/fellow-open-source.md
@@ -1,0 +1,52 @@
+---
+title: Public AI Fellow, Open Source
+location: Fully remote, with a preference for hubs with strong open-source AI presence (Berlin, Paris, London, San Francisco, NYC, Toronto)
+commitment: Deliverable-based, then part-time
+compensation: €5,000 stipend
+order: 4
+summary: Build and steward Public AI's relationships across the global open-source AI community.
+---
+
+This opportunity is funded by and offered in collaboration with [Current AI](https://currentai.org), a Paris-based nonprofit.
+
+**Location:** Fully remote, with a preference for hubs with strong open-source AI presence (Berlin, Paris, London, San Francisco, NYC, Toronto)  
+**Commitment:** Deliverable-based, then part-time  
+**Compensation:** €5,000 stipend  
+**Start date:** ASAP
+
+We are seeking a dynamic and mission-driven Public AI Fellow to build and steward Public AI's relationships across the global open-source AI community. This is a community-and-coordination role: part organizer, part thought leader, part project manager, part connective tissue between dozens of builders, maintainers, and contributors working on open source AI.
+
+You'll work directly with the CTO to implement Public AI and Current AI's "AI potluck" strategy—convening open-source AI contributors around a shared mission rather than shilling for any single project. Public AI's role here is the convener, not the protagonist.
+
+This isn't a developer relations job for one product. It's a movement-building job across many.
+
+## You will
+
+- Build and maintain relationships with open-source AI builders, maintainers, and contributors across the stack—training, fine-tuning, inference, evals, agents, tooling.
+- Own and operate a CRM of open-source AI people—who they are, what they're working on, what they need, where they overlap with Public AI's mission. Keep it accurate, useful, and current. Even better, come with your own CRM ;)
+- Implement the AI potluck strategy alongside the CTO—designing convenings, working sessions, and shared spaces where open-source AI builders can collaborate around public-interest goals.
+- Project-manage cross-organizational collaborations—help coordinate working groups, track commitments, follow up on threads, and make sure things actually ship.
+- Be the connector. Notice when two people should meet, when a project needs a partner, when a maintainer needs support, and make those introductions happen.
+- Strengthen Public AI's open-source presence—at conferences, in community spaces, on GitHub, and through informal one-on-one work.
+- Support our engineering team's open-source work at [github.com/forpublicai](https://github.com/forpublicai) on contributor onboarding and community engagement.
+- Work closely with our engineering team, Current AI, and peer institutions across the public AI ecosystem.
+
+## You might be a fit if you have
+
+- Existing relationships in the open-source AI community—as a contributor, organizer, community manager, or trusted operator.
+- Strong project management and coordination instincts—you can hold many threads, follow up reliably, and move things forward across organizations and time zones.
+- Comfort running a CRM (or equivalent system) and the discipline to keep it useful. You don't need to love spreadsheets, but you need to respect them.
+- Genuine community-building energy—you build relationships because you care about people and the mission, not because it's transactional.
+- Working familiarity with the open-source AI stack (foundation models, inference, fine-tuning, evals, open weights) and the public-interest questions around it (AI governance, digital sovereignty, openness debates).
+- Comfort convening rather than promoting. This role is about elevating other people's work, not Public AI's.
+- Bonus if you've organized an open-source community, foundation, working group, or recurring convening.
+- Bonus if you've worked across multiple open-source projects rather than inside a single one.
+- Bonus if you have an existing platform or following in the open-source AI world.
+
+This is an opportunity to build the connective tissue of the public-interest open-source AI movement at a critical moment, working directly with our CTO on a strategy designed to make open-source AI more than the sum of its repos. You'll work with a powerful network of international technologists, maintainers, policymakers, and public-interest organizations.
+
+---
+
+To apply, send a short email and CV to [josh@publicai.co](mailto:josh@publicai.co).
+
+[← Back to all jobs](/jobs/)

--- a/_jobs/fellow-switzerland.md
+++ b/_jobs/fellow-switzerland.md
@@ -1,0 +1,46 @@
+---
+title: Public AI Fellow, Switzerland
+location: Any major city in Switzerland, preferably Zürich
+commitment: Deliverable-based, then part-time
+compensation: 5,000 CHF stipend
+order: 3
+summary: Advance Public AI Switzerland, the Inference Utility, and Apertus ahead of the Swiss AI Summit in February 2027.
+---
+
+This opportunity is funded by and offered in collaboration with [Current AI](https://currentai.org), a Paris-based nonprofit.
+
+**Location:** Any major city in Switzerland, preferably Zürich  
+**Commitment:** Deliverable-based, then part-time  
+**Compensation:** 5,000 CHF stipend  
+**Start date:** ASAP
+
+We are seeking a dynamic and mission-driven Public AI Fellow based in Switzerland to support the growth of public AI initiatives across the country. This fellow will play a central role in advancing Public AI Switzerland, the Public AI Inference Utility, and Apertus—and in strengthening Switzerland's position as a global anchor for sovereign, publicly-governed AI infrastructure. A key throughline of the role will be building toward Public AI's participation in the Swiss AI Summit in February 2027.
+
+## You will
+
+- Support the operational growth of Public AI Switzerland, including coordination with founding partners and cantonal/federal stakeholders.
+- Help advance the Public AI Inference Utility and the deployment of Apertus as flagship examples of public AI infrastructure.
+- Build trust and support relationship development across Switzerland's public sector, national research institutions (CSCS, Swiss AI Initiative, ETH, EPFL), and AI industry.
+- Help align Swiss interests with a broader international coalition focused on public AI.
+- Contribute to the Swiss National AI Dialogue and other public deliberation efforts tied to Apertus.
+- Support preparation for Public AI's participation in the Swiss AI Summit (February 2027), including programming, partner engagement, and positioning.
+- Provide political and operational advice to support consortium-building efforts.
+- Work closely with our engineering team and the Public AI Switzerland cooperative members, alongside partners at CSCS, the Swiss AI Initiative, and peer institutions.
+
+## You might be a fit if you have
+
+- Strong operational instincts—someone who can move initiatives forward, coordinate across institutions, and keep complex workstreams on track.
+- Existing connections or credibility within Switzerland's AI, research, policy, or public sector communities.
+- Familiarity with Swiss tech, policy, and/or research ecosystems—or the social intelligence to engage with and grow such a network.
+- Working familiarity with technical subjects in open source AI (foundation models, inference infrastructure, open weights) and policy subjects (AI governance, digital sovereignty, public infrastructure).
+- A keen interest in AI, geopolitics, public infrastructure, or the future of technology governance.
+- Bonus if you have experience in diplomacy, international tech collaborations, foundation models, or national AI strategies of Switzerland or other middle-power countries.
+- Bonus if you have working proficiency in German, French, or Italian alongside English.
+
+This is an opportunity to shape Switzerland's role in a high-level international initiative, and gain a front-row seat to global AI diplomacy and infrastructure strategy. You'll work with a powerful network of international technologists, policymakers, and public interest organizations.
+
+---
+
+To apply, send a short email and CV to [josh@publicai.co](mailto:josh@publicai.co).
+
+[← Back to all jobs](/jobs/)

--- a/_jobs/founding-infrastructure-engineer.md
+++ b/_jobs/founding-infrastructure-engineer.md
@@ -1,0 +1,73 @@
+---
+title: Public AI Founding Infrastructure Engineer
+location: Fully remote, with a preference for Europe, US, or Canada
+commitment: Full-time contract
+compensation: $50,000 over 3 months, with opportunity to transition to full-time employment after
+order: 1
+summary: First dedicated infrastructure hire and technical owner of the Public AI Inference Utility's operational backbone.
+---
+
+This opportunity is funded by and offered in collaboration with [Current AI](https://currentai.org), a Paris-based nonprofit.
+
+**Location:** Fully remote, with a preference for Europe, US, or Canada  
+**Commitment:** Full-time contract  
+**Compensation:** $50,000 over 3 months, with opportunity to transition to full-time employment after  
+**Start date:** ASAP
+
+Public AI is building the Public AI Inference Utility: a public-access point for sovereign and public AI models, governed as public infrastructure. Think water, electricity, public libraries, the BBC. The utility already serves Apertus (Switzerland) and SEA-LION (Singapore) to users around the world at [chat.publicai.co](https://chat.publicai.co) and [platform.publicai.co](https://platform.publicai.co), and we're scaling toward national-scale inference with partners including CSCS, AI Singapore, AI Sweden, and Barcelona Supercomputing Center.
+
+Right now, we're a small, scrappy team punching above our weight. The utility runs, but it needs to run well—with the reliability, transparency, and operational maturity of real public infrastructure. That's where you come in.
+
+You'll be our first dedicated infrastructure hire and the technical owner of the platform's operational backbone. You'll report directly to the CTO and shape how a public AI utility actually works in production.
+
+## You will
+
+This is a hands-on builder/maintainer/integrator role. In your first three months, you'll likely:
+
+- Harden the platform for the Apertus 1.5 and Apertus 2 launch. Load test, build fallback routing, set up per-agent monitoring. This is a real public moment and the infrastructure has to hold.
+- Build end-to-end observability across OpenWebUI, AWS, CSCS, and (ideally) Infomaniak. We need integrated trace analysis and analytics so we can help our compute partners improve uptime and meet real SLAs.
+- Ship downtime warnings and fallback behavior, including in our Preview deployment. We should have had this months ago.
+- Implement routing transparency and endpoint provenance. When someone uses our chat or API, they should be able to see — and verify — which backend served their inference. This is core to what makes us a public utility.
+- Speed up chat.publicai.co. People are writing us off based on a limited preview experience. Fix that, whether by collapsing Preview into the main chat, expanding Preview's feature set, or something better we haven't thought of.
+- Improve the platform overall as a public good. Two ideas we're excited about: (1) integrating an MCP server so an agent can make changes to the inference configuration, and (2) making the utility more transparent and contributable — closer to how a public utility or active open-source project operates, even though it's a live service rather than static code.
+
+You'll have wide latitude to set priorities. We need someone who sees what's broken and fixes it, not someone who waits for tickets.
+
+## What we're looking for
+
+**Required**
+
+- Significant experience operating production inference or ML serving infrastructure — vLLM, model routing, multi-region deployments, GPU-backed services, or comparable
+- Strong distributed systems and SRE instincts: observability, incident response, fallback design, capacity planning
+- Comfort working across heterogeneous infrastructure partners (cloud providers, sovereign HPC centers, institutional IT)
+- Experience orchestrating many stacks; for better or worse you will also probably have to take on orchestrating a bunch of open source projects and dealing with the bugs that come with that
+- Maintainer and integrator energy — you like making systems reliable, legible, and contributable, and you take pride in operational excellence
+- Ability to work mostly autonomously in a small team and travel occasionally for team workshops
+
+**Most important: intrinsic motivation.**
+
+This is a nonprofit, open-source project building public goods. We need someone who actually cares about that mission and wants to build infrastructure for the public, not for a series B. We're looking for smart, creative, scrappy, intrinsically motivated, and moderately rebellious people who will challenge themselves, challenge us, and push for better. If you need a manager to tell you what to ship next, this isn't the right role.
+
+**Nice to have**
+
+- Open-source maintainer experience, especially on infrastructure or platform projects
+- Familiarity with OpenWebUI, vLLM, or similar inference stacks
+- Experience with MCP, agent tooling, or programmatic infrastructure interfaces
+- Experience working with large HPCs, e.g. national supercomputing centers
+- Background working with research labs or public-sector technology
+- Track record of making complex systems transparent and accessible to outside contributors
+
+## Logistics
+
+- **Location:** Fully remote, with a preference for the US, Canada, or Europe. Must be available for occasional team workshops.
+- **Employment:** Starting as a full- or part-time contract, with the option to graduate to a full-time employee role.
+- **Compensation:** Starting at $50,000 USD over three months, with room to scope upward for exceptional experience.
+- **Reports to:** CTO
+
+---
+
+Send a note to [josh@publicai.co](mailto:josh@publicai.co) with whatever best represents you — CV, GitHub, projects you're proud of, things you've maintained, things you've broken and fixed. Tell us why public AI matters to you.
+
+We read every application.
+
+[← Back to all jobs](/jobs/)

--- a/_jobs/research-engineer.md
+++ b/_jobs/research-engineer.md
@@ -1,0 +1,69 @@
+---
+title: Public AI Research Engineer
+location: Fully remote, with a preference for the US, Canada, or Europe
+commitment: Part-time contract
+compensation: $20,000 over three months, with opportunity to transition to a longer, full-time engagement
+order: 2
+summary: Hands-on role spanning product, frontend, backend, and open-source community work on real public AI infrastructure.
+---
+
+This opportunity is funded by and offered in collaboration with [Current AI](https://currentai.org), a Paris-based nonprofit.
+
+**Location:** Fully remote, with a preference for the US, Canada, or Europe  
+**Commitment:** Part-time contract  
+**Compensation:** $20,000 over three months, with opportunity to transition to a longer, full-time engagement  
+**Start date:** ASAP
+
+Public AI is AI as public infrastructure. Think water, electricity, public libraries, the BBC. We already serve Apertus (Switzerland) and SEA-LION (Singapore) to users around the world at [chat.publicai.co](https://chat.publicai.co) and [platform.publicai.co](https://platform.publicai.co), and we're scaling toward national-scale inference with partners including CSCS, AI Singapore, AI Sweden, and Barcelona Supercomputing Center.
+
+We're a small, scrappy team punching above our weight, and we're growing the engineering team. As a Public AI Research Engineer, you'll work alongside other research engineers and report directly to the CTO. You'll get your hands on real public infrastructure serving real users, and you'll help us figure out what a fully open source AI stack should actually look like in production.
+
+This is a great fit if you're early- to mid-career, hungry to build, and want to learn at the edge of inference infrastructure, sovereign AI, and public-interest technology.
+
+## You will
+
+This is a hands-on role that spans product, frontend, backend, and open-source community work. In your first three months, you'll likely:
+
+- Track and integrate the open-source AI stack. OpenWebUI ships fast. vLLM ships fast. LiteLLM, MCP servers, eval frameworks — all moving. You'll keep us current, fork where we need to, upstream where we can, and stitch everything into a platform that works.
+- Ship product across the stack. Frontend changes in our chat, backend changes in our routing, glue code between services. You'll touch all of it. We need someone who's comfortable shipping a UI change in the morning and debugging an inference backend in the afternoon.
+- Drive our open-source presence. Make our repos at [github.com/forpublicai](https://github.com/forpublicai) something contributors can actually engage with — clear issues, good docs, fast review. Help us behave like a real open-source project, not a closed shop with public code.
+- Prototype new capabilities. Routing transparency, endpoint provenance, MCP integrations, multimodal support, jurisdiction-aware handling. We have a long roadmap and not enough hands.
+- Be a product thinker, not just a coder. Notice what's broken in the user experience and fix it. Push back on roadmap decisions. Bring ideas, not just execution.
+
+You'll have wide latitude. We need someone who sees what's broken and ships it, not someone who waits for tickets.
+
+## What we're looking for
+
+**Required**
+
+- Demonstrated open-source chops — contributions, maintainership, or projects of your own that we can look at
+- Comfort moving across the stack: frontend (React/Svelte/similar), backend (Python/TypeScript/Go), and the glue between
+- Familiarity with the open-source AI stack — OpenWebUI, vLLM, LiteLLM, MCP, or similar
+- Product instincts: you care about what users experience, not just what compiles
+- Founder energy — you ship fast, you own what you ship, and you don't need permission to make things better
+- Ability to travel occasionally for team workshops
+
+**Most important: intrinsic motivation.**
+
+This is a nonprofit, open-source project building public goods. We need someone who actually cares about that mission and wants to build infrastructure for the public, not for a series B. We're looking for smart, creative, scrappy, intrinsically motivated, and moderately rebellious people who will challenge themselves, challenge us, and push for better. If you need a manager to tell you what to ship next, this isn't the right role.
+
+**Nice to have**
+
+- Maintainership or significant contribution history on a project in the AI/ML or developer tools space
+- Experience launching and running your own open-source project, startup, or community
+- Background in public-interest technology, civic tech, or research infrastructure
+- A track record of turning messy multi-repo systems into coherent platforms
+
+## Logistics
+
+- **Location:** Fully remote, with a preference for the US, Canada, or Europe. Must be available for occasional team workshops.
+- **Employment:** Part-time contract, $20,000 over three months. Strong fits will have the opportunity to transition to a longer or full-time engagement.
+- **Reports to:** CTO
+
+---
+
+Send a note to [josh@publicai.co](mailto:josh@publicai.co) with whatever best represents you — CV, GitHub, projects you're proud of, things you've built, things you've broken and fixed. Tell us why public AI matters to you.
+
+We read every application.
+
+[← Back to all jobs](/jobs/)

--- a/index.md
+++ b/index.md
@@ -49,7 +49,7 @@ We also host many [events](#events) (see below) and a regular [seminar series](h
 Public AI is a public, collaborative effort.
 
 - For questions about public AI or to get involved, sign up for [the newsletter](https://publicai.substack.com){:target="_blank" rel="noopener"} or [contact us](mailto:hello@publicai.network){:target="_blank" rel="noopener"}!
-- [We're recruiting](https://docs.google.com/document/d/1jtfzDaQHqHaF8gypFmqo8JZwQvgKFdYHFG2rjxLst0k/edit){:target="_blank" rel="noopener"} for specific roles, and always interested in working with aligned groups.  
+- [We're recruiting](/jobs/) for specific roles, and always interested in working with aligned groups.  
 - Our [original wiki document](https://docs.google.com/document/d/1ykjsXpTRZu4Obu9miJlkR9vIqWSLey5m0G4Utlm6HBg/edit){:target="_blank" rel="noopener"} describing public AI is publicly-editable. Suggestions welcome.
 - To edit this site (e.g. to add an event or document), visit [our GitHub](https://github.com/manymodels/publicai.network){:target="_blank" rel="noopener"}.
 

--- a/jobs/index.md
+++ b/jobs/index.md
@@ -1,0 +1,64 @@
+---
+layout: page
+title: Jobs
+nav_title: Jobs
+permalink: /jobs/
+---
+
+Open roles at the Public AI Network. These opportunities are funded by and offered in collaboration with [Current AI](https://currentai.org), a Paris-based nonprofit.
+
+<style>
+.job-list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0;
+}
+
+.job-list li {
+  border-bottom: 1px solid #e9ecef;
+  padding: 1.25rem 0;
+}
+
+.job-list li:first-child {
+  border-top: 1px solid #e9ecef;
+}
+
+.job-list a {
+  color: #007bff;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 1.1rem;
+}
+
+.job-list a:hover {
+  text-decoration: underline;
+}
+
+.job-meta {
+  display: block;
+  margin-top: 0.35rem;
+  font-size: 0.9rem;
+  color: #6c757d;
+}
+
+.job-summary {
+  margin: 0.5rem 0 0;
+  color: #495057;
+  line-height: 1.5;
+}
+</style>
+
+<ul class="job-list">
+{% assign sorted_jobs = site.jobs | sort: "order" %}
+{% for job in sorted_jobs %}
+  <li>
+    <a href="{{ job.url | relative_url }}">{{ job.title }}</a>
+    <span class="job-meta">{{ job.location }} · {{ job.commitment }}</span>
+    {% if job.summary %}
+    <p class="job-summary">{{ job.summary }}</p>
+    {% endif %}
+  </li>
+{% endfor %}
+</ul>
+
+Questions? Email [josh@publicai.co](mailto:josh@publicai.co).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new `/jobs/` page listing open roles at the Public AI Network, with individual detail pages at `/jobs/[slug]/`. Content was crawled from [metagov.org/join/jobs](https://metagov.org/join/jobs) and its linked job pages.

## Changes

- **Jobs list page** at `/jobs/` — simple list of four open roles with location, commitment, and summary
- **Job detail pages**:
  - `/jobs/founding-infrastructure-engineer/`
  - `/jobs/research-engineer/`
  - `/jobs/fellow-switzerland/`
  - `/jobs/fellow-open-source/`
- **Navbar** — "Jobs" added as the last nav item, immediately before the Repos dropdown
- **Homepage** — "We're recruiting" link now points to `/jobs/` instead of a Google Doc

## Implementation

Uses a Jekyll `jobs` collection (`_jobs/*.md`) with a list page at `jobs/index.md`. Nav active state highlights "Jobs" on all `/jobs/*` pages.

## How to test

1. Run `bundle exec jekyll serve`
2. Visit `/jobs/` and confirm all four roles appear
3. Click through to each detail page (e.g. `/jobs/fellow-switzerland/`)
4. Confirm "Jobs" appears in the navbar before "Repos" and is highlighted on job pages
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1b77634-8d4f-4156-beb0-f06d50493a1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1b77634-8d4f-4156-beb0-f06d50493a1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

