### PR TITLE
Adding Devinson Peña to contributing.md

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -618,6 +618,19 @@ The **Public AI Network** brings together a diverse coalition of researchers, pr
   </div>
 </div>
 
+<div class="card">
+  <div class="tab">Devinson Peña</div>
+  <div class="content">
+    <div class="avatar c2">DP</div>
+    <div class="name">Devinson Peña</div>
+    <div class="aff">Zurich, Switzerland</div>
+    <div class="details">
+      <b>Focus:</b> Public AI infrastructure
+    </div>
+    <div class="joined">2026</div>
+  </div>
+</div>
+
     <div class="card">
       <div class="tab">Diane Coyle</div>
       <div class="content">


### PR DESCRIPTION
Adding myself to the Contributors roster, following the invitation in `contributing.md` to add your name.

Card placed alphabetically in the A–D column, between David Pham and Diane Coyle. Markup matches the surrounding cards.

- **Name:** Devinson Peña
- **Affiliation:** Zurich, Switzerland
- **Focus:** Public AI infrastructure
- **Joined:** 2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)